### PR TITLE
Add operators for Or and intersection

### DIFF
--- a/src/Data/Context.hs
+++ b/src/Data/Context.hs
@@ -31,10 +31,10 @@ type family Mutate (l :: [*]) (a :: *) (b :: *) where
     Mutate (c ': xs) a b = c ': Mutate xs a b
     Mutate '[] a b = '[]
 
-type family Or (a :: Bool) (b :: Bool)  where
-    Or 'True b = 'True
-    Or a 'True = 'True
-    Or a b = 'False
+type family (a :: Bool) :||: (b :: Bool)  where
+    'True :||: b = 'True
+    a :||: 'True = 'True
+    a :||: b = 'False
 
 type family Contains (l :: [*]) (x :: *) where
     Contains (x ': xs) x = 'True
@@ -42,7 +42,7 @@ type family Contains (l :: [*]) (x :: *) where
     Contains z x = 'False
 
 type family Intersects (l :: [*]) (r :: [*]) where
-    Intersects l (r ': rs) = Or (Contains l r) (Intersects l rs)
+    Intersects l (r ': rs) = (Contains l r) :||: (Intersects l rs)
     Intersects l r = 'False
 
 data Context t where

--- a/src/Data/Context.hs
+++ b/src/Data/Context.hs
@@ -31,10 +31,19 @@ type family Mutate (l :: [*]) (a :: *) (b :: *) where
     Mutate (c ': xs) a b = c ': Mutate xs a b
     Mutate '[] a b = '[]
 
+type family Or (a :: Bool) (b :: Bool)  where
+    Or 'True b = 'True
+    Or a 'True = 'True
+    Or a b = 'False
+
 type family Contains (l :: [*]) (x :: *) where
     Contains (x ': xs) x = 'True
     Contains (y ': xs) x = Contains xs x
     Contains z x = 'False
+
+type family Intersects (l :: [*]) (r :: [*]) where
+    Intersects l (r ': rs) = Or (Contains l r) (Intersects l rs)
+    Intersects l r = 'False
 
 data Context t where
     EmptyContext :: Context '[]


### PR DESCRIPTION
This allows for users to extend an existing constraint for a given function. Many times I'll have functions that I want to expose to specific callers, only one of which may be part of the HList. The current implementation forces me to use value-level checks on a common abstraction. By supporting the "any of these" semantics of `Intersects` or fine-grained control provided by `:||:` individual functions are able to support contracts like "I may be called by a service or an admin" at compile time.

```haskell
-- Usual language pragmas here
data Foo
data Bar
data Baz
type Func c = (HasContextLens c Foo Foo, HasContextLens c Bar Bar)
...

foo :: (Func c, Intersects c '[Baz] ~ 'True ) => Context c -> Bool
foo _ = True


let x = undefined :. undefined :: Context (Foo ': Bar ': '[])
f x -- Fails to typecheck b/c 'c' does not have the additional required field 'Baz'

let y = undefined :. undeined :. undefined = Context (Foo ': Bar ': Baz ': '[])
f y -- Returns True

-- Unwrapping how Intersects works
g :: (Func c, (Contains c Fiz ~ 'True) :||: (Contains c Blerg ~ 'True)) => Context c -> Bool
...
...


```